### PR TITLE
Update meta description tag with app name

### DIFF
--- a/resources/templates/base.twig
+++ b/resources/templates/base.twig
@@ -4,7 +4,7 @@
     <title>{% block title %}Default{% endblock %} | {{ config.app_name }}</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="XBackBone File Manager">
+    <meta name="description" content="{{ config.app_name }} File Manager">
     <link rel="shortcut icon" href="{{ urlFor('/favicon.ico') }}" type="image/x-icon">
     <link rel="icon" href="{{ urlFor('/favicon.ico') }}" type="image/x-icon">
     <link rel="preload" href="{{ asset('/static/bootstrap/css/bootstrap.min.css') }}" as="style">


### PR DESCRIPTION
Updates the meta description tag to reflect the app name configured by the user.

Noticed that some applications (WhatsApp in my case) would show this in the previews.