### PR TITLE
ldap: ensure missing ldap user is auto-created

### DIFF
--- a/app/Controllers/Auth/LoginController.php
+++ b/app/Controllers/Auth/LoginController.php
@@ -51,7 +51,7 @@ class LoginController extends AuthController
         $password = param($request, 'password');
         $user = $this->database->query('SELECT `id`, `email`, `username`, `password`,`is_admin`, `active`, `current_disk_quota`, `max_disk_quota`, `ldap`, `copy_raw` FROM `users` WHERE `username` = ? OR `email` = ? LIMIT 1', [$username, $username])->fetch();
 
-        if ($this->config['ldap']['enabled'] && ($user->ldap ?? true)) {
+        if ($this->config['ldap']['enabled'] && (!$user || $user->ldap ?? true)) {
             $user = $this->ldapLogin($request, $username, param($request, 'password'), $user);
         }
 


### PR DESCRIPTION
If user is null, the user wasn't added in the database.