### PR TITLE
Fixes redirect bug for reverse proxy

### DIFF
--- a/app/Middleware/AuthMiddleware.php
+++ b/app/Middleware/AuthMiddleware.php
@@ -18,7 +18,7 @@ class AuthMiddleware extends Middleware
     public function __invoke(Request $request, RequestHandler $handler): ResponseInterface
     {
         if (!$this->session->get('logged', false)) {
-            $this->session->set('redirectTo', (string) $request->getUri());
+            $this->session->set('redirectTo', (string) $request->getUri()->getPath());
 
             return redirect(new Response(), route('login.show'));
         }


### PR DESCRIPTION
If you are logged out of XBackbone, and browse to `/upload` for example the direction holds the request URI, which isn't an issue unless you've got a reverse proxy in front of it. For example, if the app is running in a container on port 8080, and Traefik is doing the reverse proxying, when you try login after being redirected to the login page, the redirectTo session contains the internal port number, which causes you to be redirected to `https://mydomain.com:8080/upload` instead of the correct `https://mydomain.com/upload`