### PR TITLE
remove duplicate lines

### DIFF
--- a/resources/templates/upload/public.twig
+++ b/resources/templates/upload/public.twig
@@ -17,8 +17,6 @@
         <meta id="embed-image" property="og:image" content="{{ url }}/raw">
         <meta id="discord" name="twitter:image" content="{{ url }}/raw">
         <meta id="image-src" name="twitter:image:src" content="{{ url }}/raw">
-        <meta id="discord" name="twitter:image" content="{{ url }}/raw">
-        <meta id="image-src" name="twitter:image:src" content="{{ url }}/raw">
     {% elseif type == 'video' %}
         <meta name="twitter:card" content="player" />
         <meta name="twitter:title" content="{{ media.filename }} ({{ media.size }})" />


### PR DESCRIPTION
Meta tags are oddly repeated, after clearing my cache it removed the 2 extra lines.

Still not sure why the link preview doesn't seem to work in all apps, but lets get this fixed while I'm looking to why, maybe someone else knows 😅