### PR TITLE
Fix filter by a non-existent tag

### DIFF
--- a/app/Database/Repositories/MediaRepository.php
+++ b/app/Database/Repositories/MediaRepository.php
@@ -345,7 +345,7 @@ class MediaRepository
     protected function getMediaIdsByTagId($tagId)
     {
         $mediaIds = $this->db->query('SELECT `upload_id` FROM `uploads_tags` WHERE `tag_id` = ?', $tagId)->fetchAll();
-        $ids = [];
+        $ids = [-1];
         foreach ($mediaIds as $pivot) {
             $ids[] = $pivot->upload_id;
         }


### PR DESCRIPTION
When filtering by a non-existent tag (for example, after deleting files), I got a PDOException:
`SQLSTATE[42000]: Syntax error or access violation: 1064 check the manual that corresponds to your MariaDB server version for the right syntax to use near ') ORDER BY timestamp DESC LIMIT 27 OFFSET 0' at line 1`