### PR TITLE
[UploadController] Response now includes a `raw_url` field

### DIFF
--- a/app/Controllers/UploadController.php
+++ b/app/Controllers/UploadController.php
@@ -208,6 +208,7 @@ class UploadController extends Controller
 
         $this->json['message'] = 'OK';
         $this->json['url'] = urlFor("/{$user->user_code}/{$code}.{$fileInfo['extension']}");
+        $this->json['raw_url'] = urlFor("/{$user->user_code}/{$code}/raw.{$fileInfo['extension']}");
 
         $this->logger->info("User $user->username uploaded new media.", [$mediaId]);
 


### PR DESCRIPTION
I have sharex configured to add `/raw` to the end of every uploaded file automatically but that results in broken `.gif` thumbnails in discord and requires extra configuration steps. 

This change just includes a properly formatted `raw_url` field in the `/upload` response that can be used more easily from sharex and creates working gif thumbnails in discord.

Note: The broken gif thumbnails in discord seems to be entirely discords fault. I think they're just looking at the URL and seeing if it ends in `.gif` which is why this change fixes that behavior.