### PR TITLE
Add an app_email option to the config

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -479,7 +479,13 @@ if (!function_exists('platform_mail')) {
      */
     function platform_mail($mailbox = 'no-reply'): string
     {
+		$app_email = resolve('config')['app_email'];
+
+	if (!empty($app_email)) {
+		return $mailbox = $app_email;
+	}else{
         return $mailbox.'@'.str_ireplace('www.', '', parse_url(resolve('config')['base_url'], PHP_URL_HOST));
+		}
     }
 }
 


### PR DESCRIPTION
This allows to set "app_email" within the config.php, similar to "app_name" to enable a custom system email address instead of the default no-reply@whatever.domain.com.